### PR TITLE
Add support for multiple tests on the same day and multiple types (FBE,UEC) in one paste

### DIFF
--- a/src/app/converter.service.ts
+++ b/src/app/converter.service.ts
@@ -20,7 +20,6 @@ export class ConverterService {
     resultObject: ResultObject = { resultString: '' };
     uniqueTestTypes: Array<TestType> = [];
     sectionDate: Date[][] = [];
-    sectionRanges: Array<Array<number>> = [];
     sections: Array<number> = [];
     // Entry point to conversion
     convertPathologyResults() {
@@ -95,10 +94,6 @@ export class ConverterService {
         this.buildResultString(this.testResults);
     }
 
-    getTestDate(lineNumber,position): Date {
-      const testSection = this.getSectionforLine(lineNumber);
-      return this.sectionDate[testSection][position];
-    }
 
     validTest(testName, testValue): boolean{
       if(!testName || !testValue){
@@ -122,6 +117,7 @@ export class ConverterService {
       }
       return true;
     }
+    
     extractTestResults(lines: string[],sections: number[]) {
         for (let i = sections[0]; i < lines.length; i++) {
             const bloodTestName: string = lines[i].slice(0, 20).trim();

--- a/src/app/models/test-result.ts
+++ b/src/app/models/test-result.ts
@@ -2,5 +2,5 @@ import {TestType} from './test-type';
 export class TestResult{
   type: TestType;
   value: string;
-  datePerformed: string;
+  datePerformed: Date;
 }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -3,14 +3,28 @@
     Settings
   </div>
   <div class="card-body">
-    <div class="custom-control custom-radio custom-control-inline">
-      <input type="radio" id="customRadioInline2" name="customRadioInline1" class="custom-control-input" value="/t" ng-model="settingsService.delimiter">
-      <label class="custom-control-label" for="customRadioInline2">Spaces</label>
-    </div>
-    <div class="custom-control custom-radio custom-control-inline">
-      <input type="radio" id="customRadioInline1" name="customRadioInline1" class="custom-control-input" value=" " ng-model="settingsService.delimiter">
-      <label class="custom-control-label" for="customRadioInline1">TSV</label>
-    </div>
+    <fieldset>
+      <legend>Delimiter:</legend>
+      <div class="custom-control custom-radio custom-control-inline">
+        <input type="radio" id="customRadioInline2" name="customRadioInline1" class="custom-control-input" [value]="' '" checked="checked" [(ngModel)]="settingsService.delimiter">
+        <label class="custom-control-label" for="customRadioInline2">Spaces</label>
+      </div>
+      <div class="custom-control custom-radio custom-control-inline">
+        <input type="radio" id="customRadioInline1" name="customRadioInline1" class="custom-control-input" [value]="'&#9;'" [(ngModel)]="settingsService.delimiter">
+        <label class="custom-control-label" for="customRadioInline1">TSV</label>
+      </div>
+    </fieldset>
+    <fieldset>
+      <legend>Sort By Date:</legend>
+      <div class="custom-control custom-radio custom-control-inline">
+        <input type="radio" id="sortDeseendingTrue" name="sortDeseending" class="custom-control-input" checked="checked" [value]="true" [(ngModel)]="settingsService.sortDescending">
+        <label class="custom-control-label" for="sortDeseendingTrue">Descending</label>
+      </div>
+      <div class="custom-control custom-radio custom-control-inline">
+        <input type="radio" id="sortDeseendingFalse" name="sortDeseending" class="custom-control-input" [value]="false" [(ngModel)]="settingsService.sortDescending">
+        <label class="custom-control-label" for="sortDeseendingFalse">Ascending</label>
+      </div>
+    </fieldset>
     <hr/>
     <div *ngIf="converterService.uniqueTestTypes.length > 0">Select test types:</div>
     <div class="d-flex flex-wrap">

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -13,3 +13,7 @@
     border: solid 1px $app-accent-color;
   }
 }
+
+legend {
+  font-size: 1em;
+}

--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -11,7 +11,12 @@ import { TestResult } from '../models/test-result';
 export class SettingsService {
     delimiter = ' ';
     excludedTests: Array<string>;
+    sortDescending = true;
 
     constructor() {
+    }
+
+    toggleSort() {
+      this.sortDescending = !this.sortDescending;
     }
 }


### PR DESCRIPTION
Love the project :+1:

This pull request adds support for having multiple tests on the same date. This is done by converting the date and time lines into a date object rather than having the date as a string.

Adding support for multiple test types/sections - by that I mean allowing for the full results text with the different sections for FBE, UEC, Coags etc is done by first finding the collection date lines so that the text can be separated into sections. Then for each line you can determine which section it belongs to.

Determining if a line is actually a result is kind of hard but this is now working for my test data
- If the test name contains a colon, it is not a valid test
- if the test result when stripped of all non-numeric characters is not a number, it is not a valid test
- finally if the test name is in an array of known bad test names, it is not a valid test