### PR TITLE
Reset arrays before processing bloods

### DIFF
--- a/src/app/converter.service.ts
+++ b/src/app/converter.service.ts
@@ -33,6 +33,12 @@ export class ConverterService {
       }
     }
 
+    reset() {
+      this.testResults = [];
+      this.sectionDate = [];
+      this.sections = [];
+    }
+
      getBloodTestDates(lines: string[], sections: number[]) {
         for(let i = 0; i < sections.length - 1; i++)
         {
@@ -85,6 +91,7 @@ export class ConverterService {
     }
 
     processBlood() {
+        this.reset();
         const lines: string[] = this.inputObject.input.split('\n');
         this.sections = this.getSectionIndexs(lines);
         this.getBloodTestDates(lines, this.sections);


### PR DESCRIPTION
There is an issue with the dates array where it does not get reset before processing a new set of bloods which can lead to blank lines being added to the output.

To reproduce paste in a patient results, process, paste in another set of results with some of the same dates, process again and there will be dates/times with blank results in the output.

This PR fixes that issue.